### PR TITLE
ci: re-enable non-blocking security job and add weekly schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
+  schedule:
+    - cron: '0 3 * * 1'  # Weekly security scan (Mondays 03:00 UTC)
 
 permissions:
   contents: read
@@ -73,7 +75,7 @@ jobs:
 
   security:
     runs-on: ubuntu-latest
-    if: false  # temporarily disabled
+    continue-on-error: true  # non-blocking security scan
     
     steps:
     - uses: actions/checkout@v4
@@ -86,13 +88,13 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirements.txt
         pip install safety bandit
     
     - name: Run safety check
       run: |
-        pip install -r requirements.txt
-        safety check --json || true
+        safety check --full-report --ignore-unpinned-requirements
     
     - name: Run bandit security scan
       run: |
-        bandit -r src -f json -o bandit-report.json || true
+        bandit -r src -lll -q -f json -o bandit-report.json


### PR DESCRIPTION
- Re-enable security job (safety + bandit).
- Non-blocking via continue-on-error.
- Weekly scheduled run.